### PR TITLE
Update scala and sbt versions, fix test error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "scala-bootcamp"
 
 version := "0.2"
 
-scalaVersion := "2.13.4"
+scalaVersion := "2.13.8"
 
 // From https://tpolecat.github.io/2017/04/25/scalac-flags.html
 scalacOptions ++= Seq(
@@ -81,7 +81,7 @@ libraryDependencies ++= Seq(
   "io.monix" %% "monix-reactive" % "3.4.0",
 )
 
-addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.1" cross CrossVersion.full)
+addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full)
 
 run / fork := true
 run / connectInput := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.4
+sbt.version = 1.6.2

--- a/src/main/scala/com/evolutiongaming/bootcamp/effects/EffectsHomework1.scala
+++ b/src/main/scala/com/evolutiongaming/bootcamp/effects/EffectsHomework1.scala
@@ -56,6 +56,6 @@ object EffectsHomework1 {
     def raiseWhen(cond: Boolean)(e: => Throwable): IO[Unit] = ???
     def unlessA(cond: Boolean)(action: => IO[Unit]): IO[Unit] = ???
     def whenA(cond: Boolean)(action: => IO[Unit]): IO[Unit] = ???
-    val unit: IO[Unit] = ???
+    def unit: IO[Unit] = ???
   }
 }


### PR DESCRIPTION
- Updated minor scala version to latest in 2.13, this led to the need to update `kind-projector` to the latest version.
- Updated SBT version, mainly to add M1 compatibility
- Changed single `val` to `def` EffectsHomework1.scala, apparently `val` with `???` led to `Test suite com.evolutiongaming.bootcamp.effects.EffectsHomework1Spec failed with java.lang.NoClassDefFoundError: Could not initialize class com.evolutiongaming.bootcamp.effects.EffectsHomework1$IO$`. This error isn't critical since it would disappear once student starts to implement this homework, but it has caused confusion to some students ("Failing tests are expected, not errors like something does not compile (as it looks to me).)", this change fixes it 